### PR TITLE
Fix show and artist sync and import system

### DIFF
--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -17,7 +17,7 @@ export function AdminDashboard() {
   const verifySetlist = useMutation(api.admin.verifySetlist);
   
   // Trending sync action - simplified!
-  const syncTrending = useAction(api.admin_v2.syncTrending);
+  const syncTrending = useAction(api.admin.syncTrending);
   
   // Loading state
   const [trendingSyncing, setTrendingSyncing] = useState(false);
@@ -87,7 +87,7 @@ export function AdminDashboard() {
               <StatCard icon={<Calendar className="h-5 w-5" />} label="Shows" value={stats.totalShows} />
               <StatCard icon={<Music className="h-5 w-5" />} label="Setlists" value={stats.totalSetlists} />
               <StatCard icon={<TrendingUp className="h-5 w-5" />} label="Votes" value={stats.totalVotes} />
-              <StatCard icon={<Flag className="h-5 w-5" />} label="Pending Flags" value={stats.pendingFlags} />
+              <StatCard icon={<Flag className="h-5 w-5" />} label="Pending Flags" value={pendingFlags.length} />
             </div>
           )}
         </div>

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -261,10 +261,11 @@ export function AppLayout({ children }: AppLayoutProps) {
               <div className="hidden lg:block w-full max-w-md xl:max-w-lg">
                 <SearchBar onResultClick={(type: string, id: string, slug?: string) => {
                   if (type === 'artist') {
-                    const urlParam = slug || id;
+                    // Prefer Convex IDs if present; fall back to slug
+                    const urlParam = id.startsWith('k') ? id : (slug || id);
                     void navigate(`/artists/${urlParam}`)
                   } else if (type === 'show') {
-                    const urlParam = slug || id;
+                    const urlParam = id.startsWith('k') ? id : (slug || id);
                     void navigate(`/shows/${urlParam}`)
                   }
                 }} />

--- a/src/components/PublicDashboard.tsx
+++ b/src/components/PublicDashboard.tsx
@@ -44,6 +44,7 @@ export function PublicDashboard({ onArtistClick, onSignInRequired, navigate }: P
       const formattedShows = uniqueShows.map(show => ({
         ticketmasterId: show.ticketmasterId || show._id,
         artistTicketmasterId: show.artist?.ticketmasterId,
+        artistId: show.artist?._id, // pass local ID to avoid re-imports
         artistName: show.artist?.name || 'Unknown Artist',
         artist: show.artist,
         venueName: show.venue?.name || 'Unknown Venue',
@@ -423,7 +424,7 @@ function HorizontalScrollingSection({
 // Redesigned Show Card to Match Artist Page Style
 function PremiumShowCard({ show, onArtistClick }: {
   show: any;
-  onArtistClick: (artistTicketmasterId: string, artistName: string, genres?: string[], images?: string[]) => void;
+  onArtistClick: (artistTicketmasterId: string, artistName: string, genres?: string[], images?: string[], artistId?: string) => void;
 }) {
   const showDate = new Date(show.date);
   const isToday = showDate.toDateString() === new Date().toDateString();
@@ -474,7 +475,13 @@ function PremiumShowCard({ show, onArtistClick }: {
         )}
       </div>
       
-      <div className="relative z-10 p-5" onClick={() => onArtistClick(show.artistTicketmasterId || show.ticketmasterId, show.artist?.name || show.artistName, show.artist?.genres || [], show.artist?.images || (show.artistImage ? [show.artistImage] : []))}>
+      <div className="relative z-10 p-5" onClick={() => onArtistClick(
+        show.artistTicketmasterId || show.ticketmasterId,
+        show.artist?.name || show.artistName,
+        show.artist?.genres || [],
+        show.artist?.images || (show.artistImage ? [show.artistImage] : []),
+        show.artist?._id
+      )}>
         {/* Artist Info - Enhanced */}
         <div className="mb-4">
           <h3 className="font-bold text-foreground text-lg mb-2 transition-colors truncate">
@@ -613,7 +620,7 @@ function EmptyState({ icon, title, subtitle }: {
 // Mobile-optimized Show Card
 function MobileShowCard({ show, onArtistClick }: {
   show: any;
-  onArtistClick: (artistTicketmasterId: string, artistName: string, genres?: string[], images?: string[]) => void;
+  onArtistClick: (artistTicketmasterId: string, artistName: string, genres?: string[], images?: string[], artistId?: string) => void;
 }) {
   const showDate = new Date(show.date);
   const isToday = showDate.toDateString() === new Date().toDateString();
@@ -629,7 +636,13 @@ function MobileShowCard({ show, onArtistClick }: {
   };
   
   return (
-    <div className="mobile-card cursor-pointer" onClick={() => onArtistClick(show.artistTicketmasterId, show.artistName, [], show.artistImage ? [show.artistImage] : [])}>
+    <div className="mobile-card cursor-pointer" onClick={() => onArtistClick(
+      show.artistTicketmasterId || show.ticketmasterId,
+      show.artist?.name || show.artistName,
+      show.artist?.genres || [],
+      show.artist?.images || (show.artistImage ? [show.artistImage] : []),
+      show.artist?._id
+    )}>
       <div className="flex items-center gap-4">
         {/* Artist Image */}
         {show.artistImage && (

--- a/src/components/Trending.tsx
+++ b/src/components/Trending.tsx
@@ -197,10 +197,10 @@ export function Trending({ onArtistClick, onShowClick }: TrendingProps) {
                           {index + 1}
                         </div>
                         
-                        {show.artistImage ? (
+                        {(show.artist?.images?.[0] || show.artistImage) ? (
                           <img
-                            src={show.artistImage}
-                            alt={show.artistName}
+                            src={show.artist?.images?.[0] || show.artistImage}
+                            alt={show.artist?.name || show.artistName}
                             className="w-12 h-12 rounded object-cover"
                           />
                         ) : (
@@ -210,11 +210,11 @@ export function Trending({ onArtistClick, onShowClick }: TrendingProps) {
                         )}
                         
                         <div className="flex-1">
-                          <h3 className="font-semibold text-white">{show.artistName}</h3>
+                          <h3 className="font-semibold text-white">{show.artist?.name || show.artistName}</h3>
                           <div className="flex items-center gap-3 text-sm text-gray-400">
                             <span className="flex items-center gap-1">
                               <MapPin className="h-3.5 w-3.5" />
-                              {show.venueName}
+                              {show.venue?.name || show.venueName}
                             </span>
                             <span className="flex items-center gap-1">
                               <Calendar className="h-3.5 w-3.5" />
@@ -225,7 +225,7 @@ export function Trending({ onArtistClick, onShowClick }: TrendingProps) {
                             </span>
                           </div>
                           <div className="text-xs text-gray-500 mt-1">
-                            {show.venueCity}, {show.venueCountry}
+                            {(show.venue?.city || show.venueCity) || ''}{(show.venue?.country || show.venueCountry) ? `, ${show.venue?.country || show.venueCountry}` : ''}
                           </div>
                         </div>
                         


### PR DESCRIPTION
Refactor trending data fetching and improve navigation to fix homepage updates and artist import failures.

The previous trending system relied on separate `trendingShows` and `trendingArtists` tables which were not being correctly populated or used, leading to stale data on the homepage. This PR updates the backend to query canonical `shows` and `artists` tables directly using a `trendingRank` index. Additionally, navigation logic was improved to prefer Convex IDs over slugs, resolving issues where artist imports would fail or hang due to slug conflicts or re-imports of existing artists. The admin trending sync button was also fixed.

---
<a href="https://cursor.com/background-agent?bcId=bc-c61767f6-25fd-450c-a3fb-c2f040944c79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c61767f6-25fd-450c-a3fb-c2f040944c79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

